### PR TITLE
Un-fix the footer

### DIFF
--- a/assets/css/beautifuljekyll.css
+++ b/assets/css/beautifuljekyll.css
@@ -374,7 +374,7 @@ footer {
   font-size: 0.875rem;
   background-color: #EAEAEA;
   bottom: 0rem;
-  position: fixed;
+  /*position: fixed;*/
   width: 100%;
   
 }


### PR DESCRIPTION
The fixed footer takes a huge part of the page. Here's a small change to make it visible at the end of the page only.
